### PR TITLE
Config Encoder Counts Per Rev Removed

### DIFF
--- a/C++/PositionClosedLoop/src/Robot.cpp
+++ b/C++/PositionClosedLoop/src/Robot.cpp
@@ -38,9 +38,7 @@ private:
 		/* choose the sensor and sensor direction */
 		_talon->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative, kPIDLoopIdx, kTimeoutMs);
 		_talon->SetSensorPhase(true);
-		//_talon->ConfigEncoderCodesPerRev(XXX), // if using FeedbackDevice.QuadEncoder
-		//_talon->ConfigPotentiometerTurns(XXX), // if using FeedbackDevice.AnalogEncoder or AnalogPot
-
+		
 		/* set the peak and nominal outputs, 12V means full */
 		_talon->ConfigNominalOutputForward(0, kTimeoutMs);
 		_talon->ConfigNominalOutputReverse(0, kTimeoutMs);

--- a/Java/PositionClosedLoop/src/org/usfirst/frc/team217/robot/Robot.java
+++ b/Java/PositionClosedLoop/src/org/usfirst/frc/team217/robot/Robot.java
@@ -42,9 +42,7 @@ public class Robot extends IterativeRobot {
         /* choose the sensor and sensor direction */
         _talon.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, Constants.kPIDLoopIdx, Constants.kTimeoutMs);
         _talon.setSensorPhase(true);
-        //_talon.configEncoderCodesPerRev(XXX), // if using FeedbackDevice.QuadEncoder
-        //_talon.configPotentiometerTurns(XXX), // if using FeedbackDevice.AnalogEncoder or AnalogPot
-
+        
         /* set the peak and nominal outputs, 12V means full */
         _talon.configNominalOutputForward(0, Constants.kTimeoutMs);
         _talon.configNominalOutputReverse(0, Constants.kTimeoutMs);

--- a/Java/VelocityClosedLoop/src/org/usfirst/frc/team217/robot/Robot.java
+++ b/Java/VelocityClosedLoop/src/org/usfirst/frc/team217/robot/Robot.java
@@ -32,9 +32,7 @@ public class Robot extends IterativeRobot {
         /* first choose the sensor */
         _talon.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, 0, Constants.kTimeoutMs);
         _talon.setSensorPhase(true);
-        //_talon.configEncoderCodesPerRev(XXX), // if using FeedbackDevice.QuadEncoder
-        //_talon.configPotentiometerTurns(XXX), // if using FeedbackDevice.AnalogEncoder or AnalogPot
-
+        
         /* set the peak and nominal outputs, 12V means full */
         _talon.configNominalOutputForward(0, Constants.kTimeoutMs);
         _talon.configNominalOutputReverse(0, Constants.kTimeoutMs);


### PR DESCRIPTION
All instances of Config Encoder Counts Per Rev were removed from the examples, as talon only works in native units now.