### PR TITLE
Fixes C++ Position Closed Loop example not getting absolute position

### DIFF
--- a/C++ General/PositionClosedLoop/src/main/cpp/Robot.cpp
+++ b/C++ General/PositionClosedLoop/src/main/cpp/Robot.cpp
@@ -59,7 +59,7 @@ public:
 		_talon->ConfigFactoryDefault();
 		
 		/* lets grab the 360 degree position of the MagEncoder's absolute position */
-		int absolutePosition = _talon->GetSelectedSensorPosition(0) & 0xFFF; /* mask out the bottom12 bits, we don't care about the wrap arounds */
+		int absolutePosition = _talon->GetSensorCollection().GetPulseWidthPosition() & 0xFFF; /* mask out the bottom12 bits, we don't care about the wrap arounds */
 		/* use the low level API to set the quad encoder signal */
 		_talon->SetSelectedSensorPosition(absolutePosition, kPIDLoopIdx,
 				kTimeoutMs);


### PR DESCRIPTION
The C++ position closed loop example doesn't currently get the absolute position despite documentation saying it does. I've updated the example to match the Java example.